### PR TITLE
Closing AuthModal

### DIFF
--- a/src/components/AuthModal/AuthModal.css
+++ b/src/components/AuthModal/AuthModal.css
@@ -9,7 +9,7 @@
   justify-content: center;
   visibility: hidden;
   opacity: 0;
-  z-index: -1;
+  z-index: 999;
   display: flex;
   flex-direction: column;
 }
@@ -41,7 +41,6 @@
   transition:
     visibility 0s,
     opacity 0.5s ease-in-out;
-  z-index: 1;
 }
 
 .auth-modal__active-btn {

--- a/src/components/AuthModal/AuthModal.jsx
+++ b/src/components/AuthModal/AuthModal.jsx
@@ -8,29 +8,29 @@ import { modalRoot } from 'utils/modal';
 /**
  * modalMode - 'login' (по ум.) | 'signUp'
  */
-const AuthModal = ({ isOpen, onClose, modalMode = 'login', setModalMode }) => {
+const AuthModal = ({ isOpen, onChange, modalMode = 'login' }) => {
   useEffect(() => {
     if (isOpen) {
       const closeByEsc = (evt) => {
-        if (evt.key === 'Escape') onClose();
+        if (evt.key === 'Escape') onChange();
       };
       document.addEventListener('keydown', closeByEsc);
       return () => document.removeEventListener('keydown', closeByEsc);
     }
-  }, [isOpen, onClose]);
+  }, [isOpen, onChange]);
 
   const closeByOver = (evt) => {
     if (evt.target.classList.contains('auth-modal')) {
-      onClose();
+      onChange();
     }
   };
 
   const handleSignUpTabClick = () => {
-    setModalMode('signUp');
+    onChange('signUp');
   };
 
   const handleLoginTabClick = () => {
-    setModalMode('login');
+    onChange('login');
   };
 
   return ReactDOM.createPortal(
@@ -61,9 +61,9 @@ const AuthModal = ({ isOpen, onClose, modalMode = 'login', setModalMode }) => {
         </button>
       </div>
       {modalMode === 'login' ? (
-        <LoginForm onClose={onClose} />
+        <LoginForm onClose={onChange} />
       ) : (
-        <SignUpForm onClose={onClose} />
+        <SignUpForm onClose={onChange} />
       )}
     </div>,
     modalRoot

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -35,12 +35,14 @@ export default function Header() {
     setSearchParams({ 'modal-auth': 'login' });
   };
 
-  const deleteAuthModalParams = () => {
-    if (searchParams.has('modal-auth')) {
-      searchParams.delete('modal-auth');
-      setSearchParams(searchParams);
+  function setModalParams(mode = false) {
+    setAuthModalMode(mode);
+    if (mode) {
+      setSearchParams({'modal-auth': mode});
+    } else {
+      setSearchParams({});
     }
-  };
+  }
 
   useEffect(() => {
     const authModalMode = searchParams.get('modal-auth');
@@ -54,15 +56,6 @@ export default function Header() {
       setIsAuthModalOpen(false);
     }
   }, [searchParams]);
-
-  // Обработка кликов на табы внутри самой модалки авторизации
-  useEffect(() => {
-    /* если открыть модалку и перейти на другую страницу нашего
-    сайта (напр. на логотип кликнуть), то поисковый параметр становится false */
-    if (authModalMode !== false) {
-      setSearchParams({ 'modal-auth': authModalMode });
-    }
-  }, [authModalMode, setSearchParams]);
 
   // Установка темы, сохранённой persist-ом, при загрузке сайта
   useEffect(() => {
@@ -142,9 +135,8 @@ export default function Header() {
       </div>
       <AuthModal
         isOpen={isAuthModalOpen}
-        onClose={deleteAuthModalParams}
+        onChange={setModalParams}
         modalMode={authModalMode}
-        setModalMode={setAuthModalMode}
       />
     </header>
   );


### PR DESCRIPTION
В хэдере `useEffect` с зависимостью `setSearchParams` срабатывал каждый раз, что зацикливало состояния и вызывало другие эффекты, не давая закрыть модальное окно.
Пробовал разные решения, в итоге удалил проблемный хук, заменив его функцией при клике по вкладкам. И заодно вынес в неё логику удаления параметров. Так получилась функция `setModalParams`, которая меняет тип модалки и параметры адреса при клике на вкладки и открытии/закрытии. Минус одна лишняя зависимость и минус один пропс для модалки.

Считаю, что при открытом окне авторизации не должно быть возможности ткнуть сквозь фон на ссылки страницы. Поэтому прописал нужный z-index, чтобы бэкдроп перекрывал хэдер. Задал индекс сразу, т.к. `hidden` в любом случае делает элемент неактивным, и в начальном значении `-1` вроде как нет нужды.